### PR TITLE
Drop -d/--deps option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,21 @@ Arena is a macOS command line tool to create an Xcode project with a Swift Playg
  ~  arena --help
 OVERVIEW: Creates an Xcode project with a Playground and one or more SPM libraries imported and ready for use.
 
-USAGE: arena [options]
+USAGE: arena [--name <name>] [--libs <libs> ...] [--platform <platform>] [--force] [--outputdir <outputdir>] [--version] [<dependencies> ...]
+
+ARGUMENTS:
+  <dependencies>          Dependency url(s) and (optionally) version specification 
 
 OPTIONS:
-  --deps, -d         Dependency url(s) and (optionally) version specification [default: []]
-  --force, -f        Overwrite existing file/directory [default: false]
-  --help, -h         Display available options [default: false]
-  --libs, -l         Names of libraries to import (inferred if not provided) [default: []]
-  --name, -n         Name of directory and Xcode project [default: SPM-Playground]
-  --outputdir, -o    Directory where project folder should be saved [default: /Users/sas/Projects/Arena]
-  --platform, -p     Platform for Playground (one of 'macos', 'ios', 'tvos') [default: macos]
-  --version, -v      Display tool version [default: false]
+  -n, --name <name>       Name of directory and Xcode project (default: SPM-Playground)
+  -l, --libs <libs>       Names of libraries to import (inferred if not provided) 
+  -p, --platform <platform>
+                          Platform for Playground (one of 'macos', 'ios', 'tvos') (default: macos)
+  -f, --force             Overwrite existing file/directory 
+  -o, --outputdir <outputdir>
+                          Directory where project folder should be saved (default: /Users/sas/Projects/Arena)
+  -v, --version           Show version 
+  -h, --help              Show help information.
 ```
 
 ## Why Arena?
@@ -30,7 +34,7 @@ Arena – Spanish for "sand" – is where you battle-test your SPM packages and 
 ### Import Github repository
 
 ```
- ~  arena -d https://github.com/finestructure/Gala
+arena https://github.com/finestructure/Gala
 🔧  resolving package dependencies
 📔  libraries found: Gala
 ✅  created project in folder 'SPM-Playground'
@@ -39,7 +43,7 @@ Arena – Spanish for "sand" – is where you battle-test your SPM packages and 
 ### Import local repository
 
 ```
-arena -d ~/Projects/Parser
+arena ~/Projects/Parser
 🔧  resolving package dependencies
 📔  libraries found: Parser
 ✅  created project in folder 'SPM-Playground'
@@ -48,7 +52,7 @@ arena -d ~/Projects/Parser
 ### Import both
 
 ```
-arena -d ~/Projects/Parser https://github.com/finestructure/Gala
+arena ~/Projects/Parser https://github.com/finestructure/Gala
 🔧  resolving package dependencies
 📔  libraries found: Parser, Gala
 ✅  created project in folder 'SPM-Playground'
@@ -58,27 +62,27 @@ arena -d ~/Projects/Parser https://github.com/finestructure/Gala
 
 In case you want to fetch a particular revision, range of revisions, or branch, you can use a syntax similar to the one used in a `Package.swift` file. Here's what's supported and the corresponding package dependecy that it will create in the generated project:
 
-- `-d https://github.com/finestructure/Gala@0.1.0`
+- `https://github.com/finestructure/Gala@0.1.0`
   
   → `.package(url: "https://github.com/finestructure/Gala", .exact("0.1.0"))`
 
-- `-d https://github.com/finestructure/Gala@from:0.1.0`
+- `https://github.com/finestructure/Gala@from:0.1.0`
   
   → `.package(url: "https://github.com/finestructure/Gala", from: "0.1.0")`
 
-- `-d "https://github.com/finestructure/Gala@0.1.0..<4.0.0"`
+- `"https://github.com/finestructure/Gala@0.1.0..<4.0.0"`
 
   → `.package(url: "https://github.com/finestructure/Gala", "0.1.0"..<"4.0.0")`
 
-- `-d https://github.com/finestructure/Gala@0.1.0...4.0.0` 
+- `https://github.com/finestructure/Gala@0.1.0...4.0.0` 
 
   → `.package(url: "https://github.com/finestructure/Gala", "0.1.0"..<"4.0.1")`
 
-- `-d https://github.com/finestructure/Gala@branch:master` 
+- `https://github.com/finestructure/Gala@branch:master` 
 
   → `.package(url: "https://github.com/finestructure/Gala", .branch("master"))`
 
-- `-d https://github.com/finestructure/Gala@revision:7235531e92e71176dc31e77d6ff2b128a2602110` 
+- `https://github.com/finestructure/Gala@revision:7235531e92e71176dc31e77d6ff2b128a2602110` 
 
   → `.package(url: "https://github.com/finestructure/Gala", .revision("7235531e92e71176dc31e77d6ff2b128a2602110"))`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Arena is a macOS command line tool to create an Xcode project with a Swift Playground that's readily set up to use a Swift Package Manager library. You can reference both Github and local repositories. The latter is especially useful to spin up a Playground while working on a library.
 
 ```
- ~  arena --help
+arena --help
 OVERVIEW: Creates an Xcode project with a Playground and one or more SPM libraries imported and ready for use.
 
 USAGE: arena [--name <name>] [--libs <libs> ...] [--platform <platform>] [--force] [--outputdir <outputdir>] [--version] [<dependencies> ...]

--- a/Sources/ArenaCore/ArenaCommand.swift
+++ b/Sources/ArenaCore/ArenaCommand.swift
@@ -39,11 +39,6 @@ public struct Arena: ParsableCommand {
             help: "Name of directory and Xcode project")
     var projectName: String
 
-    @Option(name: [.customLong("deps"), .customShort("d")],
-            parsing: .upToNextOption,
-            help: "Dependency url(s) and (optionally) version specification")
-    var dependencies: [Dependency]
-
     @Option(name: [.customLong("libs"), .customShort("l")],
             parsing: .upToNextOption,
             help: "Names of libraries to import (inferred if not provided)")
@@ -66,6 +61,9 @@ public struct Arena: ParsableCommand {
     @Flag(name: [.customLong("version"), .customShort("v")],
           help: "Show version")
     var showVersion: Bool
+
+    @Argument(help: "Dependency url(s) and (optionally) version specification")
+    var dependencies: [Dependency]
 
     public init() {}
 }

--- a/Tests/ArenaTests/ArenaTests.swift
+++ b/Tests/ArenaTests/ArenaTests.swift
@@ -23,13 +23,40 @@ final class ArenaTests: XCTestCase {
     }
 
     func test_args_multiple_deps() throws {
-        let args = ["-d", "https://github.com/mxcl/Path.swift.git@1.2.3", "https://github.com/hartbit/Yaap.git@from:1.0.0"]
+        let args = ["https://github.com/mxcl/Path.swift.git@1.2.3", "https://github.com/hartbit/Yaap.git@from:1.0.0"]
         let res = try Arena.parse(args)
         XCTAssertEqual(res.dependencies, [
             Dependency(url: URL(string: "https://github.com/mxcl/Path.swift.git")!, requirement: .exact("1.2.3")),
             Dependency(url: URL(string: "https://github.com/hartbit/Yaap.git")!, requirement: .from("1.0.0"))
         ])
     }
+
+    func test_args_order() throws {
+        // ensure the --force flag (for instance) can be a trailing argument
+        do {
+            let args = ["-f", "https://github.com/mxcl/Path.swift.git@1.2.3", "https://github.com/hartbit/Yaap.git@from:1.0.0"]
+            let res = try Arena.parse(args)
+            XCTAssertEqual(res.dependencies, [
+                Dependency(url: URL(string: "https://github.com/mxcl/Path.swift.git")!, requirement: .exact("1.2.3")),
+                Dependency(url: URL(string: "https://github.com/hartbit/Yaap.git")!, requirement: .from("1.0.0"))
+            ])
+            XCTAssertTrue(res.force)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+        do {
+            let args = ["https://github.com/mxcl/Path.swift.git@1.2.3", "https://github.com/hartbit/Yaap.git@from:1.0.0", "-f"]
+            let res = try Arena.parse(args)
+            XCTAssertEqual(res.dependencies, [
+                Dependency(url: URL(string: "https://github.com/mxcl/Path.swift.git")!, requirement: .exact("1.2.3")),
+                Dependency(url: URL(string: "https://github.com/hartbit/Yaap.git")!, requirement: .from("1.0.0"))
+            ])
+            XCTAssertTrue(res.force)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
 
     func test_args_multiple_libs() throws {
         let args = ["-l", "foo", "bar"]


### PR DESCRIPTION
Drops `-d` flag, i.e.

`arena -d https://github.com/finestructure/Gala`

becomes

`arena https://github.com/finestructure/Gala`