### PR TITLE
Support GitHub shorthand syntax

### DIFF
--- a/Sources/ArenaCore/ArenaCommand.swift
+++ b/Sources/ArenaCore/ArenaCommand.swift
@@ -61,6 +61,10 @@ public struct Arena: ParsableCommand {
             help: "Directory where project folder should be saved")
     var outputPath: Path
 
+    @Flag(name: [.customLong("github"), .customShort("g")],
+          help: "Use GitHub shorthand")
+    var useGitHubShortname: Bool
+
     @Flag(name: [.customLong("version"), .customShort("v")],
           help: "Show version")
     var showVersion: Bool
@@ -96,6 +100,13 @@ extension Arena {
     }
 }
 
+extension Arena {
+    public mutating func validate() throws {
+        if useGitHubShortname {
+            dependencies = dependencies.compactMap { $0.usingGithubShorthand() }
+        }
+    }
+}
 
 extension Arena {
     public func run() throws {

--- a/Sources/ArenaCore/ArenaCommand.swift
+++ b/Sources/ArenaCore/ArenaCommand.swift
@@ -61,10 +61,6 @@ public struct Arena: ParsableCommand {
             help: "Directory where project folder should be saved")
     var outputPath: Path
 
-    @Flag(name: [.customLong("github"), .customShort("g")],
-          help: "Use GitHub shorthand")
-    var useGitHubShortname: Bool
-
     @Flag(name: [.customLong("version"), .customShort("v")],
           help: "Show version")
     var showVersion: Bool
@@ -102,9 +98,7 @@ extension Arena {
 
 extension Arena {
     public mutating func validate() throws {
-        if useGitHubShortname {
-            dependencies = dependencies.compactMap { $0.usingGithubShorthand() }
-        }
+        dependencies = dependencies.compactMap { $0.inferringGitHubShorthand() }
     }
 }
 

--- a/Sources/ArenaCore/Dependency.swift
+++ b/Sources/ArenaCore/Dependency.swift
@@ -90,14 +90,16 @@ extension Dependency: ExpressibleByArgument {
 }
 
 extension Dependency {
-    func usingGithubShorthand() -> Dependency? {
-        let shortName = url.pathComponents.suffix(2).joined(separator: "/")
-        let url = "https://github.com/\(shortName)"
+    func inferringGitHubShorthand() -> Dependency? {
+        let pathExists = path?.exists ?? false
+        guard url.isFileURL, !pathExists else { return self }
 
+        let shortName = url.pathComponents.suffix(2).joined(separator: "/")
+        let githubURL = "https://github.com/\(shortName)"
         if requirement == .path {
-            return Dependency(argument: url)
+            return Dependency(argument: githubURL)
         } else {
-            return Dependency(url: URL(string: url)!, requirement: requirement)
+            return Dependency(url: URL(string: githubURL)!, requirement: requirement)
         }
     }
 }

--- a/Sources/ArenaCore/Dependency.swift
+++ b/Sources/ArenaCore/Dependency.swift
@@ -88,3 +88,16 @@ extension Dependency: ExpressibleByArgument {
         self = dep
     }
 }
+
+extension Dependency {
+    func usingGithubShorthand() -> Dependency? {
+        let shortName = url.pathComponents.suffix(2).joined(separator: "/")
+        let url = "https://github.com/\(shortName)"
+
+        if requirement == .path {
+            return Dependency(argument: url)
+        } else {
+            return Dependency(url: URL(string: url)!, requirement: requirement)
+        }
+    }
+}

--- a/Tests/ArenaTests/ArenaTests.swift
+++ b/Tests/ArenaTests/ArenaTests.swift
@@ -212,6 +212,18 @@ final class ArenaTests: XCTestCase {
             XCTAssertEqual(dep.packageClause, #".package(path: "/foo/bar")"#)
         }
     }
+
+    func testConvertingFileDependencyIntoGitHubDependency() {
+        let dep = Dependency(url: URL(string: "file:///foo/bar")!, requirement: .path)
+        let githubDep = dep.usingGithubShorthand()!
+        XCTAssertEqual(githubDep.packageClause, #".package(url: "https://github.com/foo/bar", from: "0.0.0")"#)
+    }
+
+    func testConvertingFileDependencyIntoGitHubDependencyWithRef() {
+        let dep = Dependency(argument: "file:///foo/bar@1.2.3")!
+        let githubDep = dep.usingGithubShorthand()!
+        XCTAssertEqual(githubDep.packageClause, #".package(url: "https://github.com/foo/bar", .exact("1.2.3"))"#)
+    }
 }
 
 

--- a/Tests/ArenaTests/ArenaTests.swift
+++ b/Tests/ArenaTests/ArenaTests.swift
@@ -215,13 +215,13 @@ final class ArenaTests: XCTestCase {
 
     func testConvertingFileDependencyIntoGitHubDependency() {
         let dep = Dependency(url: URL(string: "file:///foo/bar")!, requirement: .path)
-        let githubDep = dep.usingGithubShorthand()!
+        let githubDep = dep.inferringGitHubShorthand()!
         XCTAssertEqual(githubDep.packageClause, #".package(url: "https://github.com/foo/bar", from: "0.0.0")"#)
     }
 
     func testConvertingFileDependencyIntoGitHubDependencyWithRef() {
         let dep = Dependency(argument: "file:///foo/bar@1.2.3")!
-        let githubDep = dep.usingGithubShorthand()!
+        let githubDep = dep.inferringGitHubShorthand()!
         XCTAssertEqual(githubDep.packageClause, #".package(url: "https://github.com/foo/bar", .exact("1.2.3"))"#)
     }
 }


### PR DESCRIPTION
Hi 👋 , thanks for making this great tool.

I took a quick stab at implementing GitHub shorthand syntax #25. e.g `arena apple/swift-argument-parser -g`

It would probably be cleaner to have a custom type wrapping URL that can guess if your using a GitHub reference vs a local path, but I just wanted to get something working fairly quickly. 

Feel free to push changes to my fork or close in favour of another PR if you prefer. Thanks again 👍 
