### PR TITLE
Fix RxSwift, Vapor: limit libraries if exact match

### DIFF
--- a/Tests/ArenaTests/ArenaTests.swift
+++ b/Tests/ArenaTests/ArenaTests.swift
@@ -43,6 +43,14 @@ final class ArenaTests: XCTestCase {
                        [.macos("10.15"), .ios("13.0"), .tvos("13.0"), .watchos("6.0")])
     }
 
+    func test_getPackageInfo_matching_library() throws {
+        // See https://github.com/finestructure/Arena/issues/75 for details.
+        XCTAssertEqual(try getPackageInfo(in: fixturesDirectory/"RxSwift"),
+                       .init(name: "RxSwift", platforms: [], libraries: ["RxSwift"]))
+        XCTAssertEqual(try getPackageInfo(in: fixturesDirectory/"Vapor"),
+                       .init(name: "vapor", platforms: [.macos("10.15")], libraries: ["Vapor"]))
+    }
+
     func test_args_multiple_deps() throws {
         let args = ["https://github.com/mxcl/Path.swift.git@1.2.3", "https://github.com/hartbit/Yaap.git@from:1.0.0"]
         let res = try Arena.parse(args)

--- a/Tests/Fixtures/RxSwift/Package.swift
+++ b/Tests/Fixtures/RxSwift/Package.swift
@@ -1,0 +1,69 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let buildTests = false
+
+extension Product {
+  static func allTests() -> [Product] {
+    if buildTests {
+      return [.executable(name: "AllTestz", targets: ["AllTestz"])]
+    } else {
+      return []
+    }
+  }
+}
+
+extension Target {
+  static func rxCocoa() -> [Target] {
+    #if os(Linux)
+      return [.target(name: "RxCocoa", dependencies: ["RxSwift", "RxRelay"])]
+    #else
+      return [.target(name: "RxCocoa", dependencies: ["RxSwift", "RxRelay", "RxCocoaRuntime"])]
+    #endif
+  }
+
+  static func rxCocoaRuntime() -> [Target] {
+    #if os(Linux)
+      return []
+    #else
+      return [.target(name: "RxCocoaRuntime", dependencies: ["RxSwift"])]
+    #endif
+  }
+
+  static func allTests() -> [Target] {
+    if buildTests {
+      return [.target(name: "AllTestz", dependencies: ["RxSwift", "RxCocoa", "RxBlocking", "RxTest"])]
+    } else {
+      return []
+    }
+  }
+}
+
+let package = Package(
+  name: "RxSwift",
+  products: ([
+    [
+      .library(name: "RxSwift", targets: ["RxSwift"]),
+      .library(name: "RxCocoa", targets: ["RxCocoa"]),
+      .library(name: "RxRelay", targets: ["RxRelay"]),
+      .library(name: "RxBlocking", targets: ["RxBlocking"]),
+      .library(name: "RxTest", targets: ["RxTest"]),
+    ],
+    Product.allTests()
+  ] as [[Product]]).flatMap { $0 },
+  targets: ([
+    [
+      .target(name: "RxSwift", dependencies: []),
+    ], 
+    Target.rxCocoa(),
+    Target.rxCocoaRuntime(),
+    [
+      .target(name: "RxRelay", dependencies: ["RxSwift"]),
+      .target(name: "RxBlocking", dependencies: ["RxSwift"]),
+      .target(name: "RxTest", dependencies: ["RxSwift"]),
+    ],
+    Target.allTests()
+  ] as [[Target]]).flatMap { $0 },
+  swiftLanguageVersions: [.v5]
+)

--- a/Tests/Fixtures/Vapor/Package.swift
+++ b/Tests/Fixtures/Vapor/Package.swift
@@ -1,0 +1,113 @@
+// swift-tools-version:5.2
+import PackageDescription
+
+let package = Package(
+    name: "vapor",
+    platforms: [
+       .macOS(.v10_15)
+    ],
+    products: [
+        .library(name: "Vapor", targets: ["Vapor"]),
+        .library(name: "XCTVapor", targets: ["XCTVapor"]),
+        .library(name: "_Vapor3", targets: ["_Vapor3"]),
+    ],
+    dependencies: [
+        // HTTP client library built on SwiftNIO
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.2.0"),
+    
+        // Sugary extensions for the SwiftNIO library
+        .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
+
+        // 💻 APIs for creating interactive CLI tools.
+        .package(url: "https://github.com/vapor/console-kit.git", from: "4.0.0"),
+
+        // 🔑 Hashing (BCrypt, SHA2, HMAC), encryption (AES), public-key (RSA), and random data generation.
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
+
+        // 🚍 High-performance trie-node router.
+        .package(url: "https://github.com/vapor/routing-kit.git", from: "4.0.0"),
+
+        // 💥 Backtraces for Swift on Linux
+        .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.1.1"),
+        
+        // Event-driven network application framework for high performance protocol servers & clients, non-blocking.
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
+        
+        // Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
+        
+        // HTTP/2 support for SwiftNIO
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.13.0"),
+        
+        // Useful code around SwiftNIO.
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.0.0"),
+        
+        // Swift logging API
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+
+        // Swift metrics API
+        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.0.0"),
+
+        // WebSocket client library built on SwiftNIO
+        .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.0.0"),
+    ],
+    targets: [
+        // C helpers
+        .target(name: "CBase32"),
+        .target(name: "CBcrypt"),
+        .target(name: "CMultipartParser"),
+        .target(name: "COperatingSystem"),
+        .target(name: "CURLParser"),
+
+        // Vapor
+        .target(name: "Vapor", dependencies: [
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "AsyncKit", package: "async-kit"),
+            .product(name: "Backtrace", package: "swift-backtrace"),
+            .target(name: "CBase32"),
+            .target(name: "CBcrypt"),
+            .target(name: "CMultipartParser"),
+            .target(name: "COperatingSystem"),
+            .target(name: "CURLParser"),
+            .product(name: "ConsoleKit", package: "console-kit"),
+            .product(name: "Logging", package: "swift-log"),
+            .product(name: "Metrics", package: "swift-metrics"),
+            .product(name: "NIO", package: "swift-nio"),
+            .product(name: "NIOExtras", package: "swift-nio-extras"),
+            .product(name: "NIOFoundationCompat", package: "swift-nio"),
+            .product(name: "NIOHTTPCompression", package: "swift-nio-extras"),
+            .product(name: "NIOHTTP1", package: "swift-nio"),
+            .product(name: "NIOHTTP2", package: "swift-nio-http2"),
+            .product(name: "NIOSSL", package: "swift-nio-ssl"),
+            .product(name: "NIOWebSocket", package: "swift-nio"),
+            .product(name: "Crypto", package: "swift-crypto"),
+            .product(name: "RoutingKit", package: "routing-kit"),
+            .product(name: "WebSocketKit", package: "websocket-kit"),
+        ]),
+        // Vapor 3 API shim
+        .target(name: "_Vapor3", dependencies: [
+            .target(name: "Vapor"),
+            .product(name: "_NIO1APIShims", package: "swift-nio")
+        ]),
+
+        // Development
+        .target(name: "Development", dependencies: [
+            .target(name: "Vapor"),
+            .target(name: "_Vapor3"),
+        ], swiftSettings: [
+            // Enable better optimizations when building in Release configuration. Despite the use of
+            // the `.unsafeFlags` construct required by SwiftPM, this flag is recommended for Release
+            // builds. See <https://github.com/swift-server/guides#building-for-production> for details.
+            .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
+        ]),
+
+        // Testing
+        .target(name: "XCTVapor", dependencies: [
+            .target(name: "Vapor"),
+        ]),
+        .testTarget(name: "VaporTests", dependencies: [
+            .product(name: "NIOTestUtils", package: "swift-nio"),
+            .target(name: "XCTVapor"),
+        ]),
+    ]
+)


### PR DESCRIPTION
Partially addresses #75 : it doesn't fix the issue with `XCTest` per se but makes packages that include it but don't need the associated test libraries (like `RxTest` and `XCTVapor`) usable.