### PR TITLE
sample code

### DIFF
--- a/Sources/ArenaCore/ArenaCommand.swift
+++ b/Sources/ArenaCore/ArenaCommand.swift
@@ -211,22 +211,11 @@ extension Arena {
         // add playground
         do {
             try playgroundPath.mkdir()
-            let libsToImport = !libNames.isEmpty ? libNames : packageInfo.flatMap { $0.1.libraries }
-            let importClauses =
-                """
-                // Playground generated with 🏟 Arena (https://github.com/finestructure/arena)
-                // ℹ️ If running the playground fails with an error "no such module ..."
-                //    go to Product -> Build to re-trigger building the SPM package.
-                // ℹ️ Please restart Xcode if autocomplete is not working.
-                """ + "\n\n" +
-                libsToImport.map { "import \($0)" }.joined(separator: "\n") + "\n"
-            try importClauses.write(to: playgroundPath/"Contents.swift")
-            try """
-                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-                <playground version='5.0' target-platform='\(platform)' buildActiveScheme='true'>
-                <timeline fileName='timeline.xctimeline'/>
-                </playground>
-                """.write(to: playgroundPath/"contents.xcplayground")
+            let libraries = !libNames.isEmpty ? libNames : packageInfo.flatMap { $0.1.libraries }
+            try PackageGenerator.importLibrariesClause(libraries: libraries)
+                .write(to: playgroundPath/"Contents.swift")
+            try PackageGenerator.contentsXCPlayground(platform: platform)
+                .write(to: playgroundPath/"contents.xcplayground")
         }
 
         if book {

--- a/Sources/ArenaCore/Dependency.swift
+++ b/Sources/ArenaCore/Dependency.swift
@@ -53,6 +53,13 @@ public struct Dependency: Equatable, Hashable, Codable {
         requirement == .path ? nil : packageDir/".build/checkouts"/url.lastPathComponent(dropExtension: "git")
     }
 
+    /// Returns path to the package source code. Local directory if the dependency is a `path` requirement, otherwise the checkout directory of the given package directory.
+    /// - Parameter packageDir: fallback package directory
+    /// - Returns: source directory
+    func sourceDir(packageDir: Path) -> Path? {
+        path ?? checkoutDir(packageDir: packageDir)
+    }
+
     func packageClause(name: String? = nil) -> String {
         #if swift(>=5.2)
         let n = name.map { #"name: "\#($0)", "# } ?? ""

--- a/Sources/ArenaCore/PackageGenerator.swift
+++ b/Sources/ArenaCore/PackageGenerator.swift
@@ -72,6 +72,25 @@ extension PackageGenerator {
             ]
             """
     }
+
+    static func importLibrariesClause(libraries: [String]) -> String {
+        """
+        // Playground generated with 🏟 Arena (https://github.com/finestructure/arena)
+        // ℹ️ If running the playground fails with an error "no such module ..."
+        //    go to Product -> Build to re-trigger building the SPM package.
+        // ℹ️ Please restart Xcode if autocomplete is not working.
+        """ + "\n\n" +
+        libraries.map { "import \($0)" }.joined(separator: "\n") + "\n"
+    }
+
+    static func contentsXCPlayground(platform: Platform) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <playground version='5.0' target-platform='\(platform)' buildActiveScheme='true'>
+        <timeline fileName='timeline.xctimeline'/>
+        </playground>
+        """
+    }
 }
 
 

--- a/Sources/ArenaCore/PackageGenerator.swift
+++ b/Sources/ArenaCore/PackageGenerator.swift
@@ -1,3 +1,6 @@
+import Path
+
+
 enum PackageGenerator {
     static func productsClause(_ info: [(Dependency, PackageInfo)]) -> String {
         info
@@ -90,6 +93,14 @@ extension PackageGenerator {
         <timeline fileName='timeline.xctimeline'/>
         </playground>
         """
+    }
+
+    static func sampleCode(path: Path) -> String? {
+        let samplePath = path/".arena-sample.swift"
+        if samplePath.exists {
+            return try? String(contentsOf: samplePath)
+        }
+        return nil
     }
 }
 

--- a/Tests/ArenaTests/PackageGeneratorTests.swift
+++ b/Tests/ArenaTests/PackageGeneratorTests.swift
@@ -42,4 +42,16 @@ class PackageGeneratorTests: XCTestCase {
                        record: false)
     }
 
+    func test_importLibrariesClause() throws {
+        assertSnapshot(matching: PackageGenerator.importLibrariesClause(libraries: ["A", "B"]),
+                       as: .lines,
+                       record: false)
+    }
+
+    func test_contentsXCPlayground() throws {
+        assertSnapshot(matching: PackageGenerator.contentsXCPlayground(platform: .macos),
+                       as: .lines,
+                       record: false)
+    }
+
 }

--- a/Tests/ArenaTests/__Snapshots__/PackageGeneratorTests/test_contentsXCPlayground.1.txt
+++ b/Tests/ArenaTests/__Snapshots__/PackageGeneratorTests/test_contentsXCPlayground.1.txt
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='macos' buildActiveScheme='true'>
+<timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/Tests/ArenaTests/__Snapshots__/PackageGeneratorTests/test_importLibrariesClause.1.txt
+++ b/Tests/ArenaTests/__Snapshots__/PackageGeneratorTests/test_importLibrariesClause.1.txt
@@ -1,0 +1,7 @@
+// Playground generated with 🏟 Arena (https://github.com/finestructure/arena)
+// ℹ️ If running the playground fails with an error "no such module ..."
+//    go to Product -> Build to re-trigger building the SPM package.
+// ℹ️ Please restart Xcode if autocomplete is not working.
+
+import A
+import B


### PR DESCRIPTION
Adds support for a `.arena-sample.swift` file to pre-populate the generated playground with sample code.

Fixes #74 